### PR TITLE
Add Protected Audience API rename banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
+
 # FLEDGE documentation
 
 This GitHub repository contains proposals for the Privacy Sandbox's

--- a/bidding_auction_services_api.md
+++ b/bidding_auction_services_api.md
@@ -1,3 +1,5 @@
+> FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
+
 **Authors:** <br>
 [Priyanka Chatterjee][26], Google Privacy Sandbox<br> 
 Itay Sharfi, Google Privacy Sandbox

--- a/bidding_auction_services_aws_guide.md
+++ b/bidding_auction_services_aws_guide.md
@@ -1,3 +1,5 @@
+> FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
+
 **Authors:** <br>
 [Daniel Kocoj][49], Google Privacy Sandbox
 

--- a/key_value_service_trust_model.md
+++ b/key_value_service_trust_model.md
@@ -1,3 +1,5 @@
+> FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
+
 # FLEDGE Key/Value service trust model
 
 Authors:

--- a/key_value_user_defined_functions.md
+++ b/key_value_user_defined_functions.md
@@ -1,3 +1,5 @@
+> FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
+
 # Key/Value service user-defined functions (UDFs)
 
 * Author: Lusa Zhan

--- a/trusted_services_overview.md
+++ b/trusted_services_overview.md
@@ -1,3 +1,5 @@
+> FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
+
 **Authors:** <br>
 [Priyanka Chatterjee][1], Google Privacy Sandbox<br>
 [Alexandra White][2], Google Chrome<br>


### PR DESCRIPTION
This PR adds a banner to reflect the new name for FLEDGE: "Protected Audience API"

Announcement blog post: https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge