### PR TITLE
docs: add 'adComponents' field to AdWithBid in generateBid() spec

### DIFF
--- a/bidding_auction_services_api.md
+++ b/bidding_auction_services_api.md
@@ -534,6 +534,7 @@ generateBid(interestGroup, auctionSignals, perBuyerSignals, trustedBiddingSignal
   return {'ad': adObject,
           'bid': bidValue,
           'render': renderUrl,
+          'adComponents': ["adComponentRenderUrlOne", "adComponentRenderUrlTwo"],
           'allowComponentAuction': false};
  } 
 ```


### PR DESCRIPTION
Added the field to the AdWithBid return value and gave example values.